### PR TITLE
fix: handle case for migrationDisabled being 0 element in enum

### DIFF
--- a/src/store/v3MigrationSelectors.ts
+++ b/src/store/v3MigrationSelectors.ts
@@ -427,7 +427,7 @@ export const selectSelectedBorrowReservesForMigration = (store: RootStore, times
 export const selectSelectedBorrowReservesForMigrationV3 = (store: RootStore, timestamp: number) => {
   const { userReservesData: userReservesDataV3 } = selectV3UserSummary(store, timestamp);
   const selectedUserReserves = selectSelectedBorrowReservesForMigration(store, timestamp)
-    .filter((userReserve) => !userReserve.migrationDisabled)
+    .filter((userReserve) => userReserve.migrationDisabled === undefined)
     // debtKey should be mapped for v3Migration
     .map((borrowReserve) => {
       let debtKey = borrowReserve.debtKey;


### PR DESCRIPTION
## General Changes

- `migrationDisabled` is an enum, and the 0 element is the condition for a borrow being disabled due to isolation mode. With this change, the final array of assets to migrate will exclude borrow assets which are disabled due to isolation mode

## Developer Notes

Add any notes here that may be helpful for reviewers.

---

## Author Checklist

Please ensure you, the author, have gone through this checklist to ensure there is an efficient workflow for the reviewers.

- [ ]  The base branch is set to `main`
- [ ]  The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
- [ ]  The Github issue has been linked to the PR in the Development section
- [ ]  The General Changes section has been filled out
- [ ]  Developer Notes have been added (optional)

**If the PR is ready for review:**

- [ ]  The PR is in `Open` state and not in `Draft` mode
- [ ]  The `Ready for Dev Review` label has been added

## Reviewer Checklist

Please ensure you, as the reviewer(s), have gone through this checklist to ensure that the code changes are ready to ship safely and to help mitigate any downstream issues that may occur.

- [ ]  End-to-end tests are passing without any errors
- [ ]  Code style generally follows existing patterns
- [ ]  Code changes do not significantly increase the application bundle size
- [ ]  If there are new 3rd-party packages, they do not introduce potential security threats
- [ ]  If there are new environment variables being added, they have been added to the `.env.example` file as well as the pertinant `.github/actions/*` files
- [ ]  There are no CI changes, or they have been approved by the DevOps and Engineering team(s)
- [ ]  Code changes have been quality checked in the ephemeral URL
- [ ]  QA verification has been completed
- [ ]  There are two or more approvals from the core team
- [ ]  Squash and merge has been checked
